### PR TITLE
Remove Unnecessary log output

### DIFF
--- a/ColorfulItems/Data/Scripts/Sisk/Mod.cs
+++ b/ColorfulItems/Data/Scripts/Sisk/Mod.cs
@@ -219,7 +219,6 @@ namespace Sisk.ColorfulIcons {
                 }
 
                 definition.Icons[0] = $"{ModContext.ModPath}\\{iconPath}";
-                MyLog.Default.WriteLineAndConsole($"{definition.Id} -> {ModContext.ModPath}\\{iconPath}");
             }
         }
 


### PR DESCRIPTION
The writing of all the textures the mod is replacing to the log file is making it needlessly large and much harder to parse for debugging mods.

if you do want to keep this feature for debugging purposes then I am willing to add it to the mod config as an opt in option